### PR TITLE
Fix to add support for String arrays in factories

### DIFF
--- a/lib/monky.js
+++ b/lib/monky.js
@@ -246,11 +246,15 @@ Monky.prototype.set = function(model, instance, path, value, saveRelated, cb) {
   } else if (value instanceof Array) {
     // Embedded document / Array handling
     value.forEach(function(sub) {
-      Object.keys(sub).forEach(function(path) {
-        if (sub.hasOwnProperty(path)) {
-          sub[path] = sequence(sub[path]);
-        }
-      });
+      if (sub instanceof Object) {
+        Object.keys(sub).forEach(function(path) {
+          if (sub.hasOwnProperty(path)) {
+            sub[path] = sequence(sub[path]);
+          }
+        });
+      } else {
+        sub = sequence(sub);
+      }
     });
 
     instance[path] = value;

--- a/test/monky.js
+++ b/test/monky.js
@@ -21,7 +21,7 @@ describe('Monky', function() {
       active: { type: 'boolean' },
       street: { type: 'string' },
       city:   { type: 'string' },
-      email:  { type: 'string' },
+      emails: [String],
       addresses: [AddressSchema]
     });
 
@@ -303,6 +303,17 @@ describe('Monky', function() {
 
     monky.build('Admin', function(err, admin) {
       expect(admin.username).to.be(username);
+      done();
+    });
+  });
+
+  it('handles array as a value', function(done) {
+    monky.factory('User', { username: 'user with emails', emails: ['one@example.org', 'two@example.org'] });
+
+    monky.build('User', function(err, user) {
+      if (err) return done(err);
+      expect(user.isNew).to.be(true);
+      expect(user.emails.length).to.be(2);
       done();
     });
   });


### PR DESCRIPTION
I got a `TypeError: Object.keys called on non-object` when trying to include a basic String array in a factory. This is a fix for that problem.

I'm not sure if this is the best way to solve it, so feel free to give feedback if you want this to be solved in a different way.
