### PR TITLE
Advanced reference implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,15 +53,24 @@ Monky also supports references between documents:
 
 ```js
 monky.factory('User', { username: 'foo' });
-monky.factory('Message', { _user: 'User' });
+monky.factory('Message', { user: monky.ref('User') });
 
 monky.build('Message', function(message) {
-  console.log(message._user.username); // 'foo'
+  console.log(message.user.username); // 'foo'
 });
 ```
 
-Every attribute that starts with an underscore will be treated as reference. The
-according factory must be defined before it can be used in a reference.
+Referring to the specific path is also supported:
+```js
+monky.factory('User', { username: 'bar' });
+monky.factory('Message', { user_id: monky.ref('User', 'id') });
+
+monky.build('Message', function(message) {
+  console.log(message.user_id); // 53c6e964002c233e013ff4f8
+});
+```
+
+The according factory must be defined before it can be used in a reference.
 
 ## Use factories to build/create mongoose documents
 

--- a/lib/monky.js
+++ b/lib/monky.js
@@ -59,6 +59,17 @@ Monky.prototype.factory = function(model, options, cb) {
 };
 
 /**
+ * Returns an instance of MonkyRef for given `model` and optional `path`
+ *
+ * @param {String} model   Mongoose model name, needs to be initialized first using `mongoose.model`
+ * @param {String} path    Path, optional
+ */
+
+Monky.prototype.ref = function(model, path) {
+    return new MonkyRef(model, path);
+};
+
+/**
  * Returns sequence number for given `path` in `model`
  *
  * @param {String}  model  Mongoose model name to return sequence number for
@@ -259,16 +270,20 @@ Monky.prototype.set = function(model, instance, path, value, saveRelated, cb) {
 
     instance[path] = value;
     cb(null);
-  } else if ('_' == path.charAt(0)) {
+  } else if (value instanceof MonkyRef) {
     // Reference
     var fn = this.build;
     if (saveRelated) fn = this.create;
 
-    fn.bind(this)(value, function(err, result) {
+    fn.bind(this)(value.model, function(err, result) {
       if (err) return cb(err);
 
-      instance.populated(path, result);
-      instance[path] = result;
+      if ('string' === typeof value.path) {
+        instance[path] = result[value.path];
+      } else {
+        instance.populated(path, result);
+        instance[path] = result;
+      }
       cb(null);
     });
   } else {
@@ -292,6 +307,15 @@ Monky.prototype.reset = function(factory) {
   }
 
   return this;
+}
+
+/**
+ * MonkyRef constructor
+ */
+
+function MonkyRef(model, path) {
+  this.model = model;
+  this.path = path;
 }
 
 /**

--- a/test/monky.js
+++ b/test/monky.js
@@ -27,7 +27,7 @@ describe('Monky', function() {
 
     var MessageSchema = new mongoose.Schema({
       body: 'string',
-      _user: {
+      user: {
         type: mongoose.Schema.Types.ObjectId,
         ref: 'User'
       }
@@ -200,7 +200,7 @@ describe('Monky', function() {
   });
 
   it('throws error if related factory is not present', function(done) {
-    monky.factory('Message', { body: 'Hi!', _user: 'User' });
+    monky.factory('Message', { body: 'Hi!', user: monky.ref('User') });
 
     monky.build('Message', function(err) {
       expect(err).to.not.be(null);
@@ -212,11 +212,23 @@ describe('Monky', function() {
     var username = 'referenced_name';
 
     monky.factory('User', { username: username });
-    monky.factory('Message', { body: 'Hi!', _user: 'User' });
+    monky.factory('Message', { body: 'Hi!', user: monky.ref('User') });
 
     monky.build('Message', function(err, message) {
       if (err) return done(err);
-      expect(message._user.username).to.be(username)
+      expect(message.user.username).to.be(username)
+
+      message.save(done);
+    });
+  });
+
+  it('creates related document and obtains the specific path', function(done) {
+    monky.factory('User', { username: 'referenced_path_name' });
+    monky.factory('Message', { body: 'Hi!', user: monky.ref('User', 'id') });
+
+    monky.build('Message', function(err, message) {
+      if (err) return done(err);
+      expect(message.user).to.match(/^[0-9a-fA-F]{24}$/)
 
       message.save(done);
     });


### PR DESCRIPTION
Using special names for reference attributes (starting with an underscore) is a limited approach, which imposes restrictions on models.

monky.ref() function was implemented to overcome this limitation. It can be used with any attribute and may refer to the specific path or the document itself, e.g.:

``` js
monky.factory('User', { username: 'bar' });
monky.factory('Message', { user_id: monky.ref('User', 'id') });

monky.build('Message', function(message) {
  console.log(message.user_id); // 53c6e964002c233e013ff4f8
});
```
