### PR TITLE
Fix a problem that callback isn't called if options empty

### DIFF
--- a/helpers/each.js
+++ b/helpers/each.js
@@ -1,6 +1,10 @@
 module.exports = function _each(collection, iterator, cb) {
   var done = 0;
 
+  if (collection.length === 0) {
+    return cb();
+  }
+
   collection.forEach(function(item) {
     iterator(item, function(err) {
       done += 1;


### PR DESCRIPTION
I got a problem like this:

```
monky.factory('User', {});

monky.build('User', function(err, user){
  // Never here is executed.
});
```

It was troubled when I test the document that applies the default value of the mongoose side:

```
var userSchema = new mongoose.Schema({
  name:
    type: String
    default: 'Default Name'
});
```
