### PR TITLE
Added test for passing a reference to create

### DIFF
--- a/test/monky.js
+++ b/test/monky.js
@@ -246,6 +246,32 @@ describe('Monky', function() {
     });
   });
 
+  it('allows to use created object ids as reference', function(done) {
+    var username = 'a-different-username';
+
+    monky.factory('User', { username: 'username' });
+    monky.factory('Message', { body: 'Hi!', user: monky.ref('User') });
+
+    monky.create('User', { username: username }, function(err, user) {
+      if (err) return done(err);
+      monky.create('Message', { user: user._id }, function(err, message) {
+        if (err) return done(err);
+        expect(message.user.username).to.be(username);
+        message.save(done);
+      });
+    });
+  });
+
+  it('allows to unset a related object', function(done) {
+    monky.factory('Message', { body: 'Hi!', user: monky.ref('User') });
+
+    monky.create('Message', { user: null }, function(err, message) {
+      if (err) return done(err);
+      expect(message.user).to.eq(null);
+      message.save(done);
+    });
+  });
+
   it('creates related document if factory is present', function(done) {
     var username = 'referenced_name';
 


### PR DESCRIPTION
Failing tests for #20.

We actually use both patterns in our code base (pass by reference and by id), as both were working in 0.4. Also in some tests we are specifically unsetting a related object (to test validation logic).
