### PR TITLE
Fix initialization in case of mixed path

### DIFF
--- a/lib/monky.js
+++ b/lib/monky.js
@@ -291,6 +291,7 @@ Monky.prototype.set = function(model, instance, path, value, saveRelated, cb) {
     instance[path] = value;
     cb(null);
   } else if (value && 'object' == typeof value) {
+    instance[path] = {};
     _each(Object.keys(value), function(key, eachDone) {
       if (value.hasOwnProperty(key)) {
         self.set(model, instance[path], key, value[key], saveRelated, eachDone);

--- a/test/monky.js
+++ b/test/monky.js
@@ -30,7 +30,8 @@ describe('Monky', function() {
       street: { type: 'string' },
       city:   { type: 'string' },
       emails: [String],
-      addresses: [AddressSchema]
+      addresses: [AddressSchema],
+      data: {}
     });
 
     var MessageSchema = new mongoose.Schema({
@@ -105,6 +106,24 @@ describe('Monky', function() {
       if (err) return done(err);
       expect(user.country.number).to.match(/country \d/);
       expect(user.country.capital.number).to.match(/capital \d/);
+      done();
+    });
+  });
+
+  it('should correctly initialize a mixed path', function(done) {
+    var data = {
+      one: 1,
+      two: 2,
+      three: 3
+    };
+    monky.factory('User', {
+      username: 'mixed path test',
+      data: data
+    });
+
+    monky.build('User', function(err, user) {
+      if (err) return done(err);
+      expect(user.data).to.eql(data);
       done();
     });
   });


### PR DESCRIPTION
This quick fix seems to work well with mixed paths and nested objects as well. PR closes issue #24.
