### PR TITLE
Fix: Cb is not defined if createList fails

### DIFF
--- a/lib/monky.js
+++ b/lib/monky.js
@@ -155,7 +155,7 @@ Monky.prototype._doList = function(model, count, userParams, create, cb) {
 
   _each(range(count), function(_, eachDone) {
     fn.bind(self)(model, userParams, function(err, instance) {
-      if (err) return cb(err, null);
+      if (err) return promise.reject(err);
       instances.push(instance);
       eachDone();
     });


### PR DESCRIPTION
# Background 
If a user uses `createList` or `buildList` with `async/await` but it fails Mongo Validation the user will see 

`cb is not defined` instead of a rejected promise. 

eg: 

`const users = await monky.createList('users', 3, { name: 'blah blah'});` 
If there was a unique constraint on name and the mongo driver raised 

```
MongoError: E11000 duplicate key error collection:
```

We would expect to see the MongoError and not the cb undefined error. 


# What changed

Return the rejected promise instead of executing undefined callback. 

